### PR TITLE
Show UID & Invite All means all color & Reviewed can_join

### DIFF
--- a/friend.as
+++ b/friend.as
@@ -302,9 +302,9 @@ package {
       this.btnInvite.x = 270;
       this.btnInvite.y = 5;
 
-      // if(!this.can_join) this.btnJoin.disabled = true;
-      // else this.btnJoin.addEventListener(MouseEvent.CLICK,this.onJoin);
-      this.btnJoin.addEventListener(MouseEvent.CLICK,this.onJoin);
+      if(!this.can_join) this.btnJoin.disabled = true;
+      else this.btnJoin.addEventListener(MouseEvent.CLICK,this.onJoin);
+      // this.btnJoin.addEventListener(MouseEvent.CLICK,this.onJoin);
 
       this.btnInvite.addEventListener(MouseEvent.CLICK,this.onInvite);
 
@@ -376,8 +376,8 @@ package {
     }
 
     public function onJoin(e:MouseEvent) : void {
-      ExternalInterface.call("OnJoinWorld", this.uid);
-      // if(this.can_join) ExternalInterface.call("OnJoinWorld", this.uid);
+      // ExternalInterface.call("OnJoinWorld", this.uid);
+      if(this.can_join) ExternalInterface.call("OnJoinWorld", this.uid);
     }
 
     public function onAccept(e:MouseEvent) : void {

--- a/friend.as
+++ b/friend.as
@@ -16,7 +16,7 @@ package {
 
     public var friends:Friends;
 
-    private var _uid:String;
+    private var _uid:TextField;
     public var bg:Shape;
     private var _name:TextField;
     private var _is_online:Shape;
@@ -64,11 +64,15 @@ package {
     }
 
     public function set uid(uid:String) : void {
-      this._uid = uid;
+      if(!this._uid) {
+        this._uid = renderer.text("", 200, 0, 10, "left", -1, -1);
+        this._uid.textColor = 0xCECED7;
+      }
+      this._uid.text = uid;
     }
 
     public function get uid() : String {
-      return this._uid;
+      return this._uid.text;
     }
 
     public function set can_join(can_join:Boolean) : void {
@@ -276,6 +280,7 @@ package {
       this._row.addChild(this._is_online);
       this._row.addChild(this._rank);
       this._row.addChild(this._name);
+      this._row.addChild(this._uid);
       this._row.addChild(this._world);
       this._row.addChild(this.btnJoin);
       this._row.addChild(this.btnInvite);

--- a/ui/Header.as
+++ b/ui/Header.as
@@ -204,7 +204,8 @@ package ui {
     }
 
     private function inviteAll(e:MouseEvent) : void {
-      this.friends.inviteColor(config.cfg.active_color);
+      for each (var color:String in config.colors)
+        this.friends.inviteColor(color);
     }
 
     // Others


### PR DESCRIPTION
* Show UID
  There are people who engage in unfriendly behavior and avoid sight by changing their names, and UIDs make it easier to pinpoint who is who
* Invite All means all color
  I feel like a button is needed to be able to pull up the invitation list in all colors. I'm just sloppily overlaying all the color lists, without deduplication, and I'm not very good at using Adobe Flash. My idea is that a relatively large dashboard is needed to interact with it, as the buttons are a bit small at the moment.
* Reviewed can_join
  It should be a bad thing to bypass the player's invisibility to join the other party, and I think a lot of bad things will happen if you remove this restriction.
![QQ20240731-021918](https://github.com/user-attachments/assets/ff4a5b63-944d-48f4-aa24-091feb1fee4a)
